### PR TITLE
[9.0][FIX] project_task_report: not able to print chatter

### DIFF
--- a/project_task_report/__openerp__.py
+++ b/project_task_report/__openerp__.py
@@ -6,7 +6,7 @@
 {
     "name": "Project Task Report",
     "summary": "Basic report for project tasks.",
-    "version": "9.0.1.0.0",
+    "version": "9.0.1.1.0",
     "author": "Eficent, "
               "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/project-reporting",

--- a/project_task_report/views/project_task_chatter_report.xml
+++ b/project_task_report/views/project_task_chatter_report.xml
@@ -63,7 +63,7 @@
                                         <div t-if="msg.subject"><span t-field="msg.subject"/>: </div>
                                         <div t-if="msg.message_type == 'notification'">
                                             <span t-field="msg.subtype_id.name"/>
-                                            <t t-foreach='msg.tracking_value_ids' t-as='value'>
+                                            <t t-foreach='msg.sudo().tracking_value_ids' t-as='value'>
                                                 <li>
                                                     <t t-esc="value.field_desc"/>:
                                                     <span> <t t-esc="value.new_value_char"/> </span>


### PR DESCRIPTION
Due to this [recent change](https://github.com/odoo/odoo/commit/f8c974cf6e1615790e83b98bce5da7370e18f68c#diff-6b73cd22e52fe242f680a79201cbd9b7) in odoo core, users are not able to print the report with the chatter.