### PR TITLE
[11.0][FIX] project_task_report: some users are not able to print tracking values.

### DIFF
--- a/project_task_report/views/project_task_chatter_report.xml
+++ b/project_task_report/views/project_task_chatter_report.xml
@@ -65,7 +65,7 @@
                                         <div t-if="msg.subject"><span t-field="msg.subject"/>: </div>
                                         <div t-if="msg.message_type == 'notification'">
                                             <span t-field="msg.subtype_id.name"/>
-                                            <t t-foreach='msg.tracking_value_ids' t-as='value'>
+                                            <t t-foreach='msg.sudo().tracking_value_ids' t-as='value'>
                                                 <li>
                                                     <t t-esc="value.field_desc"/>:
                                                     <span> <t t-esc="value.new_value_char"/> </span>


### PR DESCRIPTION
But they are able to see them in the chatter widget.