### PR TITLE
[FIX] project_task_report: show description header only when the description of the task is defined

### DIFF
--- a/project_task_report/readme/CONTRIBUTORS.rst
+++ b/project_task_report/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Lois Rilo <lois.rilo@eficent.com>
 * Serpent Consulting Services Pvt. Ltd. <contact@serpentcs.com>
+* Alan Ramos <alan.ramos@jarsa.com.mx>

--- a/project_task_report/views/project_task_chatter_report.xml
+++ b/project_task_report/views/project_task_chatter_report.xml
@@ -48,9 +48,11 @@
                                 </td>
                             </tr>
                         </table>
-                        <center><h3>Description</h3></center>
-                        <span t-field="o.description"/>
-                        <hr/>
+                        <t t-if="o.description">
+                            <center><h3>Description</h3></center>
+                            <span t-field="o.description"/>
+                            <hr/>
+                        </t>
                         <center><h3>Chatter</h3></center>
                         <table>
                             <t t-foreach="o.message_ids" t-as="msg">

--- a/project_task_report/views/project_task_report.xml
+++ b/project_task_report/views/project_task_report.xml
@@ -48,8 +48,10 @@
                                 </td>
                             </tr>
                         </table>
+                        <t t-if="o.description">
                             <center><h3>Description</h3></center>
                             <span t-field="o.description"/>
+                        </t>
                     </div>
                 </t>
             </t>


### PR DESCRIPTION
This PR allows showing the Description header in the report only when the description is defined.